### PR TITLE
Add Postgres DAO with geolocation indexing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.7.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>5.10.2</version>

--- a/src/main/java/com/alpinecattracker/Main.java
+++ b/src/main/java/com/alpinecattracker/Main.java
@@ -1,17 +1,30 @@
 package com.alpinecattracker;
 
+import com.alpinecattracker.dao.CatLocationDao;
+import com.alpinecattracker.dao.PostgresCatLocationDao;
 import java.time.Duration;
+import javax.sql.DataSource;
+import org.postgresql.ds.PGSimpleDataSource;
 
 /**
  * Example application showing how to use {@link CatTrackerService}.
  */
 public class Main {
     public static void main(String[] args) {
-        CatTrackerService tracker = new CatTrackerService(new MockAirTagClient(), Duration.ofHours(24));
+        CatLocationDao dao = new PostgresCatLocationDao(createDataSource());
+        CatTrackerService tracker = new CatTrackerService(new MockAirTagClient(), dao, Duration.ofHours(24));
         tracker.addCat(new Cat("1", "Milo", "milo.jpg"));
         tracker.addCat(new Cat("2", "Luna", "luna.jpg"));
         tracker.startPolling(Duration.ofMinutes(5));
 
         Runtime.getRuntime().addShutdownHook(new Thread(tracker::shutdown));
+    }
+
+    private static DataSource createDataSource() {
+        PGSimpleDataSource ds = new PGSimpleDataSource();
+        ds.setURL(System.getenv().getOrDefault("DB_URL", "jdbc:postgresql://localhost:5432/cats"));
+        ds.setUser(System.getenv().getOrDefault("DB_USER", "postgres"));
+        ds.setPassword(System.getenv().getOrDefault("DB_PASSWORD", "postgres"));
+        return ds;
     }
 }

--- a/src/main/java/com/alpinecattracker/dao/CatLocationDao.java
+++ b/src/main/java/com/alpinecattracker/dao/CatLocationDao.java
@@ -1,0 +1,25 @@
+package com.alpinecattracker.dao;
+
+import com.alpinecattracker.CatLocation;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * DAO for persisting and querying cat locations.
+ */
+public interface CatLocationDao {
+    /**
+     * Persists a location for the given cat id.
+     */
+    void saveLocation(String catId, CatLocation location);
+
+    /**
+     * Returns the most recent location for the given cat id.
+     */
+    Optional<CatLocation> getLatestLocation(String catId);
+
+    /**
+     * Removes all locations older than the provided cutoff.
+     */
+    void cleanupOlderThan(Instant cutoff);
+}

--- a/src/main/java/com/alpinecattracker/dao/InMemoryCatLocationDao.java
+++ b/src/main/java/com/alpinecattracker/dao/InMemoryCatLocationDao.java
@@ -1,0 +1,39 @@
+package com.alpinecattracker.dao;
+
+import com.alpinecattracker.CatLocation;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Simple in-memory implementation used for tests.
+ */
+public class InMemoryCatLocationDao implements CatLocationDao {
+    private final Map<String, Deque<CatLocation>> history = new HashMap<>();
+
+    @Override
+    public void saveLocation(String catId, CatLocation location) {
+        history.computeIfAbsent(catId, id -> new ArrayDeque<>()).addLast(location);
+    }
+
+    @Override
+    public Optional<CatLocation> getLatestLocation(String catId) {
+        Deque<CatLocation> deque = history.get(catId);
+        if (deque == null || deque.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(deque.getLast());
+    }
+
+    @Override
+    public void cleanupOlderThan(Instant cutoff) {
+        history.values().forEach(deque -> {
+            while (!deque.isEmpty() && deque.peekFirst().getTimestamp().isBefore(cutoff)) {
+                deque.removeFirst();
+            }
+        });
+    }
+}

--- a/src/main/java/com/alpinecattracker/dao/PostgresCatLocationDao.java
+++ b/src/main/java/com/alpinecattracker/dao/PostgresCatLocationDao.java
@@ -1,0 +1,83 @@
+package com.alpinecattracker.dao;
+
+import com.alpinecattracker.CatLocation;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.Optional;
+import javax.sql.DataSource;
+
+/**
+ * PostgreSQL implementation that stores locations using PostGIS and a geolocation index.
+ */
+public class PostgresCatLocationDao implements CatLocationDao {
+    private final DataSource dataSource;
+
+    public PostgresCatLocationDao(DataSource dataSource) {
+        this.dataSource = dataSource;
+        init();
+    }
+
+    private void init() {
+        try (Connection conn = dataSource.getConnection(); Statement st = conn.createStatement()) {
+            st.execute("CREATE EXTENSION IF NOT EXISTS postgis");
+            st.execute("""
+                    CREATE TABLE IF NOT EXISTS cat_location (
+                        cat_id VARCHAR NOT NULL,
+                        location GEOGRAPHY(Point,4326) NOT NULL,
+                        timestamp TIMESTAMPTZ NOT NULL
+                    )
+                    """);
+            st.execute("CREATE INDEX IF NOT EXISTS idx_cat_location_geo ON cat_location USING GIST (location)");
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to initialize Postgres schema", e);
+        }
+    }
+
+    @Override
+    public void saveLocation(String catId, CatLocation location) {
+        String sql = "INSERT INTO cat_location(cat_id, location, timestamp) VALUES (?, ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?)";
+        try (Connection conn = dataSource.getConnection(); PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, catId);
+            ps.setDouble(2, location.getLongitude());
+            ps.setDouble(3, location.getLatitude());
+            ps.setObject(4, location.getTimestamp());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to save location", e);
+        }
+    }
+
+    @Override
+    public Optional<CatLocation> getLatestLocation(String catId) {
+        String sql = "SELECT ST_Y(location::geometry) AS latitude, ST_X(location::geometry) AS longitude, timestamp FROM cat_location WHERE cat_id=? ORDER BY timestamp DESC LIMIT 1";
+        try (Connection conn = dataSource.getConnection(); PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, catId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    double lat = rs.getDouble("latitude");
+                    double lon = rs.getDouble("longitude");
+                    Instant ts = rs.getObject("timestamp", Instant.class);
+                    return Optional.of(new CatLocation(lat, lon, ts));
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to fetch latest location", e);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void cleanupOlderThan(Instant cutoff) {
+        String sql = "DELETE FROM cat_location WHERE timestamp < ?";
+        try (Connection conn = dataSource.getConnection(); PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setObject(1, cutoff);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to cleanup old locations", e);
+        }
+    }
+}

--- a/src/test/java/com/alpinecattracker/CatTrackerServiceTest.java
+++ b/src/test/java/com/alpinecattracker/CatTrackerServiceTest.java
@@ -21,7 +21,7 @@ class CatTrackerServiceTest {
             }
             return Optional.empty();
         };
-        CatTrackerService tracker = new CatTrackerService(client, Duration.ofHours(24));
+        CatTrackerService tracker = new CatTrackerService(client, new com.alpinecattracker.dao.InMemoryCatLocationDao(), Duration.ofHours(24));
         tracker.addCat(cat);
 
         tracker.pollOnce(); // first poll returns location
@@ -44,7 +44,7 @@ class CatTrackerServiceTest {
             return Optional.empty();
         };
         Duration retention = Duration.ofMillis(500);
-        CatTrackerService tracker = new CatTrackerService(client, retention);
+        CatTrackerService tracker = new CatTrackerService(client, new com.alpinecattracker.dao.InMemoryCatLocationDao(), retention);
         tracker.addCat(cat);
 
         tracker.pollOnce(); // add initial location


### PR DESCRIPTION
## Summary
- add PostgreSQL JDBC dependency
- introduce DAO layer with in-memory and Postgres implementations using PostGIS geolocation indexing
- wire CatTrackerService and Main application to use the new DAO

## Testing
- `mvn -q test` 
